### PR TITLE
Create database connection crate

### DIFF
--- a/crates/database-connector/.gitignore
+++ b/crates/database-connector/.gitignore
@@ -1,0 +1,22 @@
+# Build artifacts
+/target/
+Cargo.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Test databases
+*.db
+*.sqlite
+*.sqlite3
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/crates/database-connector/Cargo.toml
+++ b/crates/database-connector/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "database-connector"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# Database drivers
+sqlx = { version = "0.7", features = ["runtime-tokio-native-tls", "sqlite", "postgres", "chrono", "uuid"] }
+tokio = { version = "1", features = ["full"] }
+
+# Async trait
+async-trait = "0.1"
+
+# Error handling
+thiserror = "1.0"
+anyhow = "1.0"
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Logging
+log = "0.4"
+
+# Configuration
+config = "0.13"
+
+[dev-dependencies]
+tokio-test = "0.4"

--- a/crates/database-connector/examples/basic_usage.rs
+++ b/crates/database-connector/examples/basic_usage.rs
@@ -1,0 +1,225 @@
+//! Basic usage example for the database-connector crate
+
+use database_connector::{
+    DatabaseConfig, DatabaseConnection, DatabaseOperations, QueryBuilder,
+    config::DatabaseType,
+    traits::{SelectQuery, InsertQuery, UpdateQuery, DeleteQuery},
+};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Example 1: Using SQLite (default)
+    println!("=== SQLite Example ===");
+    sqlite_example().await?;
+    
+    // Example 2: Using PostgreSQL
+    // Uncomment the following line to test PostgreSQL
+    // println!("\n=== PostgreSQL Example ===");
+    // postgres_example().await?;
+    
+    Ok(())
+}
+
+async fn sqlite_example() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a SQLite configuration
+    let config = DatabaseConfig::sqlite("test.db");
+    
+    // Create a connection
+    let conn = DatabaseConnection::new(config).await?;
+    
+    // Create a table
+    conn.execute_raw(
+        "CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT UNIQUE NOT NULL,
+            age INTEGER,
+            active BOOLEAN DEFAULT 1
+        )",
+        vec![],
+    ).await?;
+    
+    println!("Table created successfully");
+    
+    // Insert data using raw SQL
+    let rows_affected = conn.execute_raw(
+        "INSERT INTO users (name, email, age) VALUES (?, ?, ?)",
+        vec![
+            json!("Alice"),
+            json!("alice@example.com"),
+            json!(30),
+        ],
+    ).await?;
+    
+    println!("Inserted {} row(s)", rows_affected);
+    
+    // Insert more data
+    conn.execute_raw(
+        "INSERT INTO users (name, email, age) VALUES (?, ?, ?), (?, ?, ?)",
+        vec![
+            json!("Bob"),
+            json!("bob@example.com"),
+            json!(25),
+            json!("Charlie"),
+            json!("charlie@example.com"),
+            json!(35),
+        ],
+    ).await?;
+    
+    // Query data
+    let users = conn.query_raw(
+        "SELECT * FROM users WHERE age > ?",
+        vec![json!(20)],
+    ).await?;
+    
+    println!("\nUsers older than 20:");
+    for user in &users {
+        println!("{}", serde_json::to_string_pretty(user)?);
+    }
+    
+    // Using transactions
+    let mut tx = conn.begin_transaction().await?;
+    
+    tx.execute_raw(
+        "UPDATE users SET age = age + 1 WHERE name = ?",
+        vec![json!("Alice")],
+    ).await?;
+    
+    tx.execute_raw(
+        "INSERT INTO users (name, email, age) VALUES (?, ?, ?)",
+        vec![
+            json!("David"),
+            json!("david@example.com"),
+            json!(40),
+        ],
+    ).await?;
+    
+    // Commit the transaction
+    tx.commit().await?;
+    
+    println!("\nTransaction committed successfully");
+    
+    // Query all users
+    let all_users = conn.query_raw("SELECT * FROM users", vec![]).await?;
+    
+    println!("\nAll users:");
+    for user in &all_users {
+        println!("{}", serde_json::to_string_pretty(user)?);
+    }
+    
+    // Using query builder
+    let select_query = SelectQuery::new("users")
+        .columns(vec!["name", "email", "age"])
+        .where_clause("age >= 30")
+        .order_by("age", true)
+        .limit(5);
+    
+    println!("\nGenerated SELECT query: {}", select_query.build());
+    
+    let insert_query = InsertQuery::new("users")
+        .columns(vec!["name", "email", "age"])
+        .values(vec!["'Eve'", "'eve@example.com'", "28"]);
+    
+    println!("Generated INSERT query: {}", insert_query.build());
+    
+    let update_query = UpdateQuery::new("users")
+        .set("active", "0")
+        .where_clause("age < 25");
+    
+    println!("Generated UPDATE query: {}", update_query.build());
+    
+    let delete_query = DeleteQuery::new("users")
+        .where_clause("active = 0");
+    
+    println!("Generated DELETE query: {}", delete_query.build());
+    
+    // Health check
+    conn.health_check().await?;
+    println!("\nDatabase health check passed");
+    
+    // Close the connection
+    conn.close().await?;
+    
+    Ok(())
+}
+
+async fn postgres_example() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a PostgreSQL configuration
+    let config = DatabaseConfig::postgres(
+        "localhost",
+        5432,
+        "postgres",
+        "password",
+        "testdb",
+    );
+    
+    // Create a connection
+    let conn = DatabaseConnection::new(config).await?;
+    
+    // Create a table
+    conn.execute_raw(
+        "CREATE TABLE IF NOT EXISTS products (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(255) NOT NULL,
+            description TEXT,
+            price DECIMAL(10, 2),
+            in_stock BOOLEAN DEFAULT true,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )",
+        vec![],
+    ).await?;
+    
+    println!("Table created successfully");
+    
+    // Insert data
+    let rows_affected = conn.execute_raw(
+        "INSERT INTO products (name, description, price) VALUES ($1, $2, $3)",
+        vec![
+            json!("Laptop"),
+            json!("High-performance laptop"),
+            json!(999.99),
+        ],
+    ).await?;
+    
+    println!("Inserted {} row(s)", rows_affected);
+    
+    // Query data
+    let products = conn.query_raw(
+        "SELECT * FROM products WHERE price < $1",
+        vec![json!(1500.00)],
+    ).await?;
+    
+    println!("\nProducts under $1500:");
+    for product in &products {
+        println!("{}", serde_json::to_string_pretty(product)?);
+    }
+    
+    // Using transactions with rollback
+    let mut tx = conn.begin_transaction().await?;
+    
+    tx.execute_raw(
+        "INSERT INTO products (name, description, price) VALUES ($1, $2, $3)",
+        vec![
+            json!("Mouse"),
+            json!("Wireless mouse"),
+            json!(29.99),
+        ],
+    ).await?;
+    
+    // Rollback the transaction
+    tx.rollback().await?;
+    
+    println!("\nTransaction rolled back");
+    
+    // Check database type
+    match conn.database_type() {
+        DatabaseType::Postgres => println!("Connected to PostgreSQL"),
+        DatabaseType::Sqlite => println!("Connected to SQLite"),
+    }
+    
+    // Close the connection
+    conn.close().await?;
+    
+    Ok(())
+}

--- a/crates/database-connector/src/config.rs
+++ b/crates/database-connector/src/config.rs
@@ -1,0 +1,147 @@
+//! Configuration types for the database connector
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DatabaseType {
+    Sqlite,
+    Postgres,
+}
+
+impl Default for DatabaseType {
+    fn default() -> Self {
+        DatabaseType::Sqlite
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatabaseConfig {
+    #[serde(default)]
+    pub database_type: DatabaseType,
+    
+    // SQLite specific
+    pub sqlite_path: Option<PathBuf>,
+    
+    // PostgreSQL specific
+    pub postgres_host: Option<String>,
+    pub postgres_port: Option<u16>,
+    pub postgres_user: Option<String>,
+    pub postgres_password: Option<String>,
+    pub postgres_database: Option<String>,
+    
+    // Connection pool settings
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
+    
+    #[serde(default = "default_min_connections")]
+    pub min_connections: u32,
+    
+    #[serde(default = "default_connection_timeout")]
+    pub connection_timeout_seconds: u64,
+    
+    #[serde(default = "default_idle_timeout")]
+    pub idle_timeout_seconds: u64,
+}
+
+fn default_max_connections() -> u32 {
+    10
+}
+
+fn default_min_connections() -> u32 {
+    1
+}
+
+fn default_connection_timeout() -> u64 {
+    30
+}
+
+fn default_idle_timeout() -> u64 {
+    600
+}
+
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self {
+            database_type: DatabaseType::default(),
+            sqlite_path: Some(PathBuf::from("database.db")),
+            postgres_host: None,
+            postgres_port: None,
+            postgres_user: None,
+            postgres_password: None,
+            postgres_database: None,
+            max_connections: default_max_connections(),
+            min_connections: default_min_connections(),
+            connection_timeout_seconds: default_connection_timeout(),
+            idle_timeout_seconds: default_idle_timeout(),
+        }
+    }
+}
+
+impl DatabaseConfig {
+    /// Create a new SQLite configuration
+    pub fn sqlite(path: impl Into<PathBuf>) -> Self {
+        Self {
+            database_type: DatabaseType::Sqlite,
+            sqlite_path: Some(path.into()),
+            ..Default::default()
+        }
+    }
+    
+    /// Create a new PostgreSQL configuration
+    pub fn postgres(
+        host: impl Into<String>,
+        port: u16,
+        user: impl Into<String>,
+        password: impl Into<String>,
+        database: impl Into<String>,
+    ) -> Self {
+        Self {
+            database_type: DatabaseType::Postgres,
+            postgres_host: Some(host.into()),
+            postgres_port: Some(port),
+            postgres_user: Some(user.into()),
+            postgres_password: Some(password.into()),
+            postgres_database: Some(database.into()),
+            ..Default::default()
+        }
+    }
+    
+    /// Get the connection URL based on the database type
+    pub fn connection_url(&self) -> crate::Result<String> {
+        match self.database_type {
+            DatabaseType::Sqlite => {
+                let path = self.sqlite_path.as_ref()
+                    .ok_or_else(|| crate::DatabaseError::ConfigError(
+                        "SQLite path not specified".to_string()
+                    ))?;
+                Ok(format!("sqlite://{}", path.display()))
+            }
+            DatabaseType::Postgres => {
+                let host = self.postgres_host.as_ref()
+                    .ok_or_else(|| crate::DatabaseError::ConfigError(
+                        "PostgreSQL host not specified".to_string()
+                    ))?;
+                let port = self.postgres_port
+                    .unwrap_or(5432);
+                let user = self.postgres_user.as_ref()
+                    .ok_or_else(|| crate::DatabaseError::ConfigError(
+                        "PostgreSQL user not specified".to_string()
+                    ))?;
+                let password = self.postgres_password.as_ref()
+                    .ok_or_else(|| crate::DatabaseError::ConfigError(
+                        "PostgreSQL password not specified".to_string()
+                    ))?;
+                let database = self.postgres_database.as_ref()
+                    .ok_or_else(|| crate::DatabaseError::ConfigError(
+                        "PostgreSQL database not specified".to_string()
+                    ))?;
+                Ok(format!(
+                    "postgres://{}:{}@{}:{}/{}",
+                    user, password, host, port, database
+                ))
+            }
+        }
+    }
+}

--- a/crates/database-connector/src/connection.rs
+++ b/crates/database-connector/src/connection.rs
@@ -1,0 +1,438 @@
+//! Database connection implementations
+
+use async_trait::async_trait;
+use sqlx::{Pool, Sqlite, Postgres, Row as SqlxRow};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::{
+    config::{DatabaseConfig, DatabaseType},
+    error::{DatabaseError, Result},
+    traits::{DatabaseOperations, Transaction},
+};
+
+/// Enum wrapper for different database connection pools
+pub enum ConnectionPool {
+    Sqlite(Pool<Sqlite>),
+    Postgres(Pool<Postgres>),
+}
+
+/// Main database connection structure
+pub struct DatabaseConnection {
+    pool: ConnectionPool,
+    config: DatabaseConfig,
+}
+
+impl DatabaseConnection {
+    /// Create a new database connection
+    pub async fn new(config: DatabaseConfig) -> Result<Self> {
+        let pool = match config.database_type {
+            DatabaseType::Sqlite => {
+                let url = config.connection_url()?;
+                let pool = sqlx::sqlite::SqlitePoolOptions::new()
+                    .max_connections(config.max_connections)
+                    .min_connections(config.min_connections)
+                    .connect_timeout(Duration::from_secs(config.connection_timeout_seconds))
+                    .idle_timeout(Duration::from_secs(config.idle_timeout_seconds))
+                    .connect(&url)
+                    .await?;
+                ConnectionPool::Sqlite(pool)
+            }
+            DatabaseType::Postgres => {
+                let url = config.connection_url()?;
+                let pool = sqlx::postgres::PgPoolOptions::new()
+                    .max_connections(config.max_connections)
+                    .min_connections(config.min_connections)
+                    .connect_timeout(Duration::from_secs(config.connection_timeout_seconds))
+                    .idle_timeout(Duration::from_secs(config.idle_timeout_seconds))
+                    .connect(&url)
+                    .await?;
+                ConnectionPool::Postgres(pool)
+            }
+        };
+        
+        Ok(Self {
+            pool,
+            config: config.clone(),
+        })
+    }
+    
+    /// Create a new connection with default SQLite configuration
+    pub async fn default_sqlite() -> Result<Self> {
+        Self::new(DatabaseConfig::default()).await
+    }
+    
+    /// Get a reference to the configuration
+    pub fn config(&self) -> &DatabaseConfig {
+        &self.config
+    }
+    
+    /// Close all connections in the pool
+    pub async fn close(&self) -> Result<()> {
+        match &self.pool {
+            ConnectionPool::Sqlite(pool) => {
+                pool.close().await;
+                Ok(())
+            }
+            ConnectionPool::Postgres(pool) => {
+                pool.close().await;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl DatabaseOperations for DatabaseConnection {
+    async fn query_raw(&self, query: &str, params: Vec<serde_json::Value>) -> Result<Vec<serde_json::Value>> {
+        match &self.pool {
+            ConnectionPool::Sqlite(pool) => {
+                let mut sqlx_query = sqlx::query(query);
+                
+                // Bind parameters
+                for param in params {
+                    sqlx_query = match param {
+                        serde_json::Value::String(s) => sqlx_query.bind(s),
+                        serde_json::Value::Number(n) => {
+                            if let Some(i) = n.as_i64() {
+                                sqlx_query.bind(i)
+                            } else if let Some(f) = n.as_f64() {
+                                sqlx_query.bind(f)
+                            } else {
+                                return Err(DatabaseError::QueryError("Invalid number parameter".to_string()));
+                            }
+                        }
+                        serde_json::Value::Bool(b) => sqlx_query.bind(b),
+                        serde_json::Value::Null => sqlx_query.bind(None::<String>),
+                        _ => return Err(DatabaseError::QueryError("Unsupported parameter type".to_string())),
+                    };
+                }
+                
+                let rows = sqlx_query
+                    .fetch_all(pool)
+                    .await?;
+                
+                // Convert rows to JSON
+                let mut results = Vec::new();
+                for row in rows {
+                    let mut json_row = serde_json::Map::new();
+                    for (i, column) in row.columns().iter().enumerate() {
+                        let value = sqlite_row_to_json(&row, i)?;
+                        json_row.insert(column.name().to_string(), value);
+                    }
+                    results.push(serde_json::Value::Object(json_row));
+                }
+                
+                Ok(results)
+            }
+            ConnectionPool::Postgres(pool) => {
+                let mut sqlx_query = sqlx::query(query);
+                
+                // Bind parameters
+                for param in params {
+                    sqlx_query = match param {
+                        serde_json::Value::String(s) => sqlx_query.bind(s),
+                        serde_json::Value::Number(n) => {
+                            if let Some(i) = n.as_i64() {
+                                sqlx_query.bind(i)
+                            } else if let Some(f) = n.as_f64() {
+                                sqlx_query.bind(f)
+                            } else {
+                                return Err(DatabaseError::QueryError("Invalid number parameter".to_string()));
+                            }
+                        }
+                        serde_json::Value::Bool(b) => sqlx_query.bind(b),
+                        serde_json::Value::Null => sqlx_query.bind(None::<String>),
+                        _ => return Err(DatabaseError::QueryError("Unsupported parameter type".to_string())),
+                    };
+                }
+                
+                let rows = sqlx_query
+                    .fetch_all(pool)
+                    .await?;
+                
+                // Convert rows to JSON
+                let mut results = Vec::new();
+                for row in rows {
+                    let mut json_row = serde_json::Map::new();
+                    for (i, column) in row.columns().iter().enumerate() {
+                        let value = postgres_row_to_json(&row, i)?;
+                        json_row.insert(column.name().to_string(), value);
+                    }
+                    results.push(serde_json::Value::Object(json_row));
+                }
+                
+                Ok(results)
+            }
+        }
+    }
+    
+    async fn execute_raw(&self, query: &str, params: Vec<serde_json::Value>) -> Result<u64> {
+        match &self.pool {
+            ConnectionPool::Sqlite(pool) => {
+                let mut sqlx_query = sqlx::query(query);
+                
+                for param in params {
+                    sqlx_query = bind_param_sqlite(sqlx_query, param)?;
+                }
+                
+                let result = sqlx_query.execute(pool).await?;
+                Ok(result.rows_affected())
+            }
+            ConnectionPool::Postgres(pool) => {
+                let mut sqlx_query = sqlx::query(query);
+                
+                for param in params {
+                    sqlx_query = bind_param_postgres(sqlx_query, param)?;
+                }
+                
+                let result = sqlx_query.execute(pool).await?;
+                Ok(result.rows_affected())
+            }
+        }
+    }
+    
+    async fn begin_transaction(&self) -> Result<Box<dyn Transaction>> {
+        match &self.pool {
+            ConnectionPool::Sqlite(pool) => {
+                let tx = pool.begin().await?;
+                Ok(Box::new(SqliteTransaction { tx }))
+            }
+            ConnectionPool::Postgres(pool) => {
+                let tx = pool.begin().await?;
+                Ok(Box::new(PostgresTransaction { tx }))
+            }
+        }
+    }
+    
+    async fn health_check(&self) -> Result<()> {
+        match &self.pool {
+            ConnectionPool::Sqlite(pool) => {
+                sqlx::query("SELECT 1").fetch_one(pool).await?;
+                Ok(())
+            }
+            ConnectionPool::Postgres(pool) => {
+                sqlx::query("SELECT 1").fetch_one(pool).await?;
+                Ok(())
+            }
+        }
+    }
+    
+    fn database_type(&self) -> DatabaseType {
+        self.config.database_type.clone()
+    }
+}
+
+/// SQLite transaction implementation
+struct SqliteTransaction {
+    tx: sqlx::Transaction<'static, Sqlite>,
+}
+
+#[async_trait]
+impl Transaction for SqliteTransaction {
+    async fn commit(self: Box<Self>) -> Result<()> {
+        self.tx.commit().await?;
+        Ok(())
+    }
+    
+    async fn rollback(self: Box<Self>) -> Result<()> {
+        self.tx.rollback().await?;
+        Ok(())
+    }
+    
+    async fn query_raw(&mut self, query: &str, params: Vec<serde_json::Value>) -> Result<Vec<serde_json::Value>> {
+        let mut sqlx_query = sqlx::query(query);
+        
+        for param in params {
+            sqlx_query = bind_param_sqlite(sqlx_query, param)?;
+        }
+        
+        let rows = sqlx_query.fetch_all(&mut *self.tx).await?;
+        
+        let mut results = Vec::new();
+        for row in rows {
+            let mut json_row = serde_json::Map::new();
+            for (i, column) in row.columns().iter().enumerate() {
+                let value = sqlite_row_to_json(&row, i)?;
+                json_row.insert(column.name().to_string(), value);
+            }
+            results.push(serde_json::Value::Object(json_row));
+        }
+        
+        Ok(results)
+    }
+    
+    async fn execute_raw(&mut self, query: &str, params: Vec<serde_json::Value>) -> Result<u64> {
+        let mut sqlx_query = sqlx::query(query);
+        
+        for param in params {
+            sqlx_query = bind_param_sqlite(sqlx_query, param)?;
+        }
+        
+        let result = sqlx_query.execute(&mut *self.tx).await?;
+        Ok(result.rows_affected())
+    }
+}
+
+/// PostgreSQL transaction implementation
+struct PostgresTransaction {
+    tx: sqlx::Transaction<'static, Postgres>,
+}
+
+#[async_trait]
+impl Transaction for PostgresTransaction {
+    async fn commit(self: Box<Self>) -> Result<()> {
+        self.tx.commit().await?;
+        Ok(())
+    }
+    
+    async fn rollback(self: Box<Self>) -> Result<()> {
+        self.tx.rollback().await?;
+        Ok(())
+    }
+    
+    async fn query_raw(&mut self, query: &str, params: Vec<serde_json::Value>) -> Result<Vec<serde_json::Value>> {
+        let mut sqlx_query = sqlx::query(query);
+        
+        for param in params {
+            sqlx_query = bind_param_postgres(sqlx_query, param)?;
+        }
+        
+        let rows = sqlx_query.fetch_all(&mut *self.tx).await?;
+        
+        let mut results = Vec::new();
+        for row in rows {
+            let mut json_row = serde_json::Map::new();
+            for (i, column) in row.columns().iter().enumerate() {
+                let value = postgres_row_to_json(&row, i)?;
+                json_row.insert(column.name().to_string(), value);
+            }
+            results.push(serde_json::Value::Object(json_row));
+        }
+        
+        Ok(results)
+    }
+    
+    async fn execute_raw(&mut self, query: &str, params: Vec<serde_json::Value>) -> Result<u64> {
+        let mut sqlx_query = sqlx::query(query);
+        
+        for param in params {
+            sqlx_query = bind_param_postgres(sqlx_query, param)?;
+        }
+        
+        let result = sqlx_query.execute(&mut *self.tx).await?;
+        Ok(result.rows_affected())
+    }
+}
+
+// Helper functions for parameter binding
+fn bind_param_sqlite<'q>(
+    query: sqlx::query::Query<'q, Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
+    param: serde_json::Value,
+) -> Result<sqlx::query::Query<'q, Sqlite, sqlx::sqlite::SqliteArguments<'q>>> {
+    Ok(match param {
+        serde_json::Value::String(s) => query.bind(s),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                query.bind(i)
+            } else if let Some(f) = n.as_f64() {
+                query.bind(f)
+            } else {
+                return Err(DatabaseError::QueryError("Invalid number parameter".to_string()));
+            }
+        }
+        serde_json::Value::Bool(b) => query.bind(b),
+        serde_json::Value::Null => query.bind(None::<String>),
+        _ => return Err(DatabaseError::QueryError("Unsupported parameter type".to_string())),
+    })
+}
+
+fn bind_param_postgres<'q>(
+    query: sqlx::query::Query<'q, Postgres, sqlx::postgres::PgArguments>,
+    param: serde_json::Value,
+) -> Result<sqlx::query::Query<'q, Postgres, sqlx::postgres::PgArguments>> {
+    Ok(match param {
+        serde_json::Value::String(s) => query.bind(s),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                query.bind(i)
+            } else if let Some(f) = n.as_f64() {
+                query.bind(f)
+            } else {
+                return Err(DatabaseError::QueryError("Invalid number parameter".to_string()));
+            }
+        }
+        serde_json::Value::Bool(b) => query.bind(b),
+        serde_json::Value::Null => query.bind(None::<String>),
+        _ => return Err(DatabaseError::QueryError("Unsupported parameter type".to_string())),
+    })
+}
+
+// Helper functions for row conversion
+fn sqlite_row_to_json(row: &sqlx::sqlite::SqliteRow, index: usize) -> Result<serde_json::Value> {
+    use sqlx::TypeInfo;
+    use sqlx::sqlite::SqliteTypeInfo;
+    
+    let type_info = row.column(index).type_info();
+    let type_name = type_info.name();
+    
+    match type_name {
+        "TEXT" => {
+            let value: Option<String> = row.try_get(index)?;
+            Ok(value.map(serde_json::Value::String).unwrap_or(serde_json::Value::Null))
+        }
+        "INTEGER" | "BIGINT" => {
+            let value: Option<i64> = row.try_get(index)?;
+            Ok(value.map(|v| serde_json::Value::Number(v.into())).unwrap_or(serde_json::Value::Null))
+        }
+        "REAL" | "DOUBLE" => {
+            let value: Option<f64> = row.try_get(index)?;
+            Ok(value.and_then(|v| serde_json::Number::from_f64(v))
+                .map(serde_json::Value::Number)
+                .unwrap_or(serde_json::Value::Null))
+        }
+        "BOOLEAN" => {
+            let value: Option<bool> = row.try_get(index)?;
+            Ok(value.map(serde_json::Value::Bool).unwrap_or(serde_json::Value::Null))
+        }
+        _ => {
+            // Try to get as string for unknown types
+            let value: Option<String> = row.try_get(index).ok();
+            Ok(value.map(serde_json::Value::String).unwrap_or(serde_json::Value::Null))
+        }
+    }
+}
+
+fn postgres_row_to_json(row: &sqlx::postgres::PgRow, index: usize) -> Result<serde_json::Value> {
+    use sqlx::TypeInfo;
+    use sqlx::postgres::PgTypeInfo;
+    
+    let type_info = row.column(index).type_info();
+    let type_name = type_info.name();
+    
+    match type_name {
+        "TEXT" | "VARCHAR" | "CHAR" => {
+            let value: Option<String> = row.try_get(index)?;
+            Ok(value.map(serde_json::Value::String).unwrap_or(serde_json::Value::Null))
+        }
+        "INT2" | "INT4" | "INT8" => {
+            let value: Option<i64> = row.try_get(index)?;
+            Ok(value.map(|v| serde_json::Value::Number(v.into())).unwrap_or(serde_json::Value::Null))
+        }
+        "FLOAT4" | "FLOAT8" => {
+            let value: Option<f64> = row.try_get(index)?;
+            Ok(value.and_then(|v| serde_json::Number::from_f64(v))
+                .map(serde_json::Value::Number)
+                .unwrap_or(serde_json::Value::Null))
+        }
+        "BOOL" => {
+            let value: Option<bool> = row.try_get(index)?;
+            Ok(value.map(serde_json::Value::Bool).unwrap_or(serde_json::Value::Null))
+        }
+        _ => {
+            // Try to get as string for unknown types
+            let value: Option<String> = row.try_get(index).ok();
+            Ok(value.map(serde_json::Value::String).unwrap_or(serde_json::Value::Null))
+        }
+    }
+}

--- a/crates/database-connector/src/error.rs
+++ b/crates/database-connector/src/error.rs
@@ -1,0 +1,35 @@
+//! Error types for the database connector
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DatabaseError {
+    #[error("Connection error: {0}")]
+    ConnectionError(String),
+    
+    #[error("Query error: {0}")]
+    QueryError(String),
+    
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+    
+    #[error("Migration error: {0}")]
+    MigrationError(String),
+    
+    #[error("Transaction error: {0}")]
+    TransactionError(String),
+    
+    #[error("Database error: {0}")]
+    SqlxError(#[from] sqlx::Error),
+    
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+    
+    #[error("Serialization error: {0}")]
+    SerdeError(#[from] serde_json::Error),
+    
+    #[error("Unknown error: {0}")]
+    Unknown(String),
+}
+
+pub type Result<T> = std::result::Result<T, DatabaseError>;

--- a/crates/database-connector/src/lib.rs
+++ b/crates/database-connector/src/lib.rs
@@ -1,0 +1,27 @@
+//! Database Connector Crate
+//! 
+//! This crate provides an abstraction over SQLite and PostgreSQL databases,
+//! allowing for easy switching between the two backends.
+
+pub mod config;
+pub mod connection;
+pub mod error;
+pub mod models;
+pub mod traits;
+
+// Re-export main types
+pub use config::{DatabaseConfig, DatabaseType};
+pub use connection::{DatabaseConnection, ConnectionPool};
+pub use error::{DatabaseError, Result};
+pub use traits::{DatabaseOperations, QueryBuilder};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        // Basic test to ensure the crate compiles
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/crates/database-connector/src/models.rs
+++ b/crates/database-connector/src/models.rs
@@ -1,0 +1,96 @@
+//! Common models and data structures
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Represents a database row as a generic structure
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Row {
+    pub values: HashMap<String, serde_json::Value>,
+}
+
+impl Row {
+    pub fn new() -> Self {
+        Self {
+            values: HashMap::new(),
+        }
+    }
+    
+    pub fn insert(&mut self, key: impl Into<String>, value: impl Serialize) {
+        self.values.insert(
+            key.into(),
+            serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
+        );
+    }
+    
+    pub fn get<T: for<'de> Deserialize<'de>>(&self, key: &str) -> Option<T> {
+        self.values.get(key)
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+    }
+    
+    pub fn get_string(&self, key: &str) -> Option<String> {
+        self.get::<String>(key)
+    }
+    
+    pub fn get_i64(&self, key: &str) -> Option<i64> {
+        self.get::<i64>(key)
+    }
+    
+    pub fn get_f64(&self, key: &str) -> Option<f64> {
+        self.get::<f64>(key)
+    }
+    
+    pub fn get_bool(&self, key: &str) -> Option<bool> {
+        self.get::<bool>(key)
+    }
+}
+
+impl Default for Row {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Table metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableInfo {
+    pub name: String,
+    pub columns: Vec<ColumnInfo>,
+}
+
+/// Column metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnInfo {
+    pub name: String,
+    pub data_type: String,
+    pub is_nullable: bool,
+    pub is_primary_key: bool,
+    pub default_value: Option<String>,
+}
+
+/// Migration tracking
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Migration {
+    pub version: String,
+    pub description: String,
+    pub sql: String,
+    pub checksum: String,
+}
+
+/// Database statistics
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatabaseStats {
+    pub total_connections: u32,
+    pub active_connections: u32,
+    pub idle_connections: u32,
+    pub max_connections: u32,
+    pub database_size_bytes: Option<u64>,
+}
+
+/// Query result metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryResult {
+    pub rows_affected: u64,
+    pub last_insert_id: Option<i64>,
+    pub execution_time_ms: u64,
+}

--- a/crates/database-connector/src/traits.rs
+++ b/crates/database-connector/src/traits.rs
@@ -1,0 +1,242 @@
+//! Traits for database operations
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use sqlx::{Row, FromRow};
+
+/// Main trait for database operations
+#[async_trait]
+pub trait DatabaseOperations: Send + Sync {
+    /// Execute a raw SQL query that returns rows
+    async fn query_raw(&self, query: &str, params: Vec<serde_json::Value>) -> crate::Result<Vec<serde_json::Value>>;
+    
+    /// Execute a raw SQL command (INSERT, UPDATE, DELETE)
+    async fn execute_raw(&self, query: &str, params: Vec<serde_json::Value>) -> crate::Result<u64>;
+    
+    /// Begin a transaction
+    async fn begin_transaction(&self) -> crate::Result<Box<dyn Transaction>>;
+    
+    /// Check if the connection is healthy
+    async fn health_check(&self) -> crate::Result<()>;
+    
+    /// Get the database type
+    fn database_type(&self) -> crate::config::DatabaseType;
+}
+
+/// Transaction trait
+#[async_trait]
+pub trait Transaction: Send + Sync {
+    /// Commit the transaction
+    async fn commit(self: Box<Self>) -> crate::Result<()>;
+    
+    /// Rollback the transaction
+    async fn rollback(self: Box<Self>) -> crate::Result<()>;
+    
+    /// Execute a query within the transaction
+    async fn query_raw(&mut self, query: &str, params: Vec<serde_json::Value>) -> crate::Result<Vec<serde_json::Value>>;
+    
+    /// Execute a command within the transaction
+    async fn execute_raw(&mut self, query: &str, params: Vec<serde_json::Value>) -> crate::Result<u64>;
+}
+
+/// Query builder trait for constructing database-agnostic queries
+pub trait QueryBuilder {
+    /// Create a SELECT query
+    fn select(table: &str) -> SelectQuery {
+        SelectQuery::new(table)
+    }
+    
+    /// Create an INSERT query
+    fn insert(table: &str) -> InsertQuery {
+        InsertQuery::new(table)
+    }
+    
+    /// Create an UPDATE query
+    fn update(table: &str) -> UpdateQuery {
+        UpdateQuery::new(table)
+    }
+    
+    /// Create a DELETE query
+    fn delete(table: &str) -> DeleteQuery {
+        DeleteQuery::new(table)
+    }
+}
+
+/// SELECT query builder
+#[derive(Debug, Clone)]
+pub struct SelectQuery {
+    table: String,
+    columns: Vec<String>,
+    where_clause: Option<String>,
+    order_by: Option<String>,
+    limit: Option<usize>,
+    offset: Option<usize>,
+}
+
+impl SelectQuery {
+    pub fn new(table: &str) -> Self {
+        Self {
+            table: table.to_string(),
+            columns: vec!["*".to_string()],
+            where_clause: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+        }
+    }
+    
+    pub fn columns(mut self, columns: Vec<&str>) -> Self {
+        self.columns = columns.iter().map(|s| s.to_string()).collect();
+        self
+    }
+    
+    pub fn where_clause(mut self, clause: &str) -> Self {
+        self.where_clause = Some(clause.to_string());
+        self
+    }
+    
+    pub fn order_by(mut self, column: &str, desc: bool) -> Self {
+        self.order_by = Some(format!("{} {}", column, if desc { "DESC" } else { "ASC" }));
+        self
+    }
+    
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+    
+    pub fn offset(mut self, offset: usize) -> Self {
+        self.offset = Some(offset);
+        self
+    }
+    
+    pub fn build(&self) -> String {
+        let mut query = format!("SELECT {} FROM {}", self.columns.join(", "), self.table);
+        
+        if let Some(ref where_clause) = self.where_clause {
+            query.push_str(&format!(" WHERE {}", where_clause));
+        }
+        
+        if let Some(ref order_by) = self.order_by {
+            query.push_str(&format!(" ORDER BY {}", order_by));
+        }
+        
+        if let Some(limit) = self.limit {
+            query.push_str(&format!(" LIMIT {}", limit));
+        }
+        
+        if let Some(offset) = self.offset {
+            query.push_str(&format!(" OFFSET {}", offset));
+        }
+        
+        query
+    }
+}
+
+/// INSERT query builder
+#[derive(Debug, Clone)]
+pub struct InsertQuery {
+    table: String,
+    columns: Vec<String>,
+    values: Vec<Vec<String>>,
+}
+
+impl InsertQuery {
+    pub fn new(table: &str) -> Self {
+        Self {
+            table: table.to_string(),
+            columns: Vec::new(),
+            values: Vec::new(),
+        }
+    }
+    
+    pub fn columns(mut self, columns: Vec<&str>) -> Self {
+        self.columns = columns.iter().map(|s| s.to_string()).collect();
+        self
+    }
+    
+    pub fn values(mut self, values: Vec<&str>) -> Self {
+        self.values.push(values.iter().map(|s| s.to_string()).collect());
+        self
+    }
+    
+    pub fn build(&self) -> String {
+        let columns = self.columns.join(", ");
+        let values = self.values
+            .iter()
+            .map(|row| format!("({})", row.join(", ")))
+            .collect::<Vec<_>>()
+            .join(", ");
+        
+        format!("INSERT INTO {} ({}) VALUES {}", self.table, columns, values)
+    }
+}
+
+/// UPDATE query builder
+#[derive(Debug, Clone)]
+pub struct UpdateQuery {
+    table: String,
+    set_clause: Vec<String>,
+    where_clause: Option<String>,
+}
+
+impl UpdateQuery {
+    pub fn new(table: &str) -> Self {
+        Self {
+            table: table.to_string(),
+            set_clause: Vec::new(),
+            where_clause: None,
+        }
+    }
+    
+    pub fn set(mut self, column: &str, value: &str) -> Self {
+        self.set_clause.push(format!("{} = {}", column, value));
+        self
+    }
+    
+    pub fn where_clause(mut self, clause: &str) -> Self {
+        self.where_clause = Some(clause.to_string());
+        self
+    }
+    
+    pub fn build(&self) -> String {
+        let mut query = format!("UPDATE {} SET {}", self.table, self.set_clause.join(", "));
+        
+        if let Some(ref where_clause) = self.where_clause {
+            query.push_str(&format!(" WHERE {}", where_clause));
+        }
+        
+        query
+    }
+}
+
+/// DELETE query builder
+#[derive(Debug, Clone)]
+pub struct DeleteQuery {
+    table: String,
+    where_clause: Option<String>,
+}
+
+impl DeleteQuery {
+    pub fn new(table: &str) -> Self {
+        Self {
+            table: table.to_string(),
+            where_clause: None,
+        }
+    }
+    
+    pub fn where_clause(mut self, clause: &str) -> Self {
+        self.where_clause = Some(clause.to_string());
+        self
+    }
+    
+    pub fn build(&self) -> String {
+        let mut query = format!("DELETE FROM {}", self.table);
+        
+        if let Some(ref where_clause) = self.where_clause {
+            query.push_str(&format!(" WHERE {}", where_clause));
+        }
+        
+        query
+    }
+}

--- a/crates/database-connector/tests/integration_tests.rs
+++ b/crates/database-connector/tests/integration_tests.rs
@@ -1,0 +1,235 @@
+//! Integration tests for the database-connector crate
+
+use database_connector::{
+    DatabaseConfig, DatabaseConnection, DatabaseOperations,
+    config::DatabaseType,
+};
+use serde_json::json;
+use std::path::PathBuf;
+
+#[tokio::test]
+async fn test_sqlite_connection() {
+    let config = DatabaseConfig::sqlite(":memory:");
+    let conn = DatabaseConnection::new(config).await.unwrap();
+    
+    // Test health check
+    conn.health_check().await.unwrap();
+    
+    // Test database type
+    assert!(matches!(conn.database_type(), DatabaseType::Sqlite));
+    
+    conn.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_sqlite_create_table_and_insert() {
+    let config = DatabaseConfig::sqlite(":memory:");
+    let conn = DatabaseConnection::new(config).await.unwrap();
+    
+    // Create table
+    let result = conn.execute_raw(
+        "CREATE TABLE test_table (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            value INTEGER
+        )",
+        vec![],
+    ).await.unwrap();
+    
+    assert_eq!(result, 0);
+    
+    // Insert data
+    let rows_affected = conn.execute_raw(
+        "INSERT INTO test_table (name, value) VALUES (?, ?)",
+        vec![json!("test"), json!(42)],
+    ).await.unwrap();
+    
+    assert_eq!(rows_affected, 1);
+    
+    conn.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_sqlite_query() {
+    let config = DatabaseConfig::sqlite(":memory:");
+    let conn = DatabaseConnection::new(config).await.unwrap();
+    
+    // Create and populate table
+    conn.execute_raw(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)",
+        vec![],
+    ).await.unwrap();
+    
+    conn.execute_raw(
+        "INSERT INTO users (name, age) VALUES (?, ?), (?, ?), (?, ?)",
+        vec![
+            json!("Alice"), json!(30),
+            json!("Bob"), json!(25),
+            json!("Charlie"), json!(35),
+        ],
+    ).await.unwrap();
+    
+    // Query data
+    let results = conn.query_raw(
+        "SELECT * FROM users WHERE age > ? ORDER BY age",
+        vec![json!(25)],
+    ).await.unwrap();
+    
+    assert_eq!(results.len(), 2);
+    
+    // Check first result
+    let first = &results[0];
+    assert_eq!(first.get("name"), Some(&json!("Alice")));
+    assert_eq!(first.get("age"), Some(&json!(30)));
+    
+    conn.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_sqlite_transaction_commit() {
+    let config = DatabaseConfig::sqlite(":memory:");
+    let conn = DatabaseConnection::new(config).await.unwrap();
+    
+    // Create table
+    conn.execute_raw(
+        "CREATE TABLE test_tx (id INTEGER PRIMARY KEY, value TEXT)",
+        vec![],
+    ).await.unwrap();
+    
+    // Begin transaction
+    let mut tx = conn.begin_transaction().await.unwrap();
+    
+    // Insert data in transaction
+    tx.execute_raw(
+        "INSERT INTO test_tx (value) VALUES (?)",
+        vec![json!("test_value")],
+    ).await.unwrap();
+    
+    // Commit transaction
+    tx.commit().await.unwrap();
+    
+    // Verify data was committed
+    let results = conn.query_raw("SELECT * FROM test_tx", vec![]).await.unwrap();
+    assert_eq!(results.len(), 1);
+    
+    conn.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_sqlite_transaction_rollback() {
+    let config = DatabaseConfig::sqlite(":memory:");
+    let conn = DatabaseConnection::new(config).await.unwrap();
+    
+    // Create table
+    conn.execute_raw(
+        "CREATE TABLE test_rollback (id INTEGER PRIMARY KEY, value TEXT)",
+        vec![],
+    ).await.unwrap();
+    
+    // Begin transaction
+    let mut tx = conn.begin_transaction().await.unwrap();
+    
+    // Insert data in transaction
+    tx.execute_raw(
+        "INSERT INTO test_rollback (value) VALUES (?)",
+        vec![json!("should_be_rolled_back")],
+    ).await.unwrap();
+    
+    // Rollback transaction
+    tx.rollback().await.unwrap();
+    
+    // Verify data was not committed
+    let results = conn.query_raw("SELECT * FROM test_rollback", vec![]).await.unwrap();
+    assert_eq!(results.len(), 0);
+    
+    conn.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_config_default() {
+    let config = DatabaseConfig::default();
+    assert!(matches!(config.database_type, DatabaseType::Sqlite));
+    assert_eq!(config.sqlite_path, Some(PathBuf::from("database.db")));
+    assert_eq!(config.max_connections, 10);
+    assert_eq!(config.min_connections, 1);
+}
+
+#[tokio::test]
+async fn test_config_sqlite() {
+    let config = DatabaseConfig::sqlite("custom.db");
+    assert!(matches!(config.database_type, DatabaseType::Sqlite));
+    assert_eq!(config.sqlite_path, Some(PathBuf::from("custom.db")));
+}
+
+#[tokio::test]
+async fn test_config_postgres() {
+    let config = DatabaseConfig::postgres("localhost", 5432, "user", "pass", "db");
+    assert!(matches!(config.database_type, DatabaseType::Postgres));
+    assert_eq!(config.postgres_host, Some("localhost".to_string()));
+    assert_eq!(config.postgres_port, Some(5432));
+    assert_eq!(config.postgres_user, Some("user".to_string()));
+    assert_eq!(config.postgres_password, Some("pass".to_string()));
+    assert_eq!(config.postgres_database, Some("db".to_string()));
+}
+
+#[tokio::test]
+async fn test_connection_url_sqlite() {
+    let config = DatabaseConfig::sqlite("test.db");
+    let url = config.connection_url().unwrap();
+    assert_eq!(url, "sqlite://test.db");
+}
+
+#[tokio::test]
+async fn test_connection_url_postgres() {
+    let config = DatabaseConfig::postgres("localhost", 5432, "user", "pass", "testdb");
+    let url = config.connection_url().unwrap();
+    assert_eq!(url, "postgres://user:pass@localhost:5432/testdb");
+}
+
+#[tokio::test]
+async fn test_query_builder() {
+    use database_connector::traits::{SelectQuery, InsertQuery, UpdateQuery, DeleteQuery};
+    
+    // Test SELECT query builder
+    let select = SelectQuery::new("users")
+        .columns(vec!["id", "name", "email"])
+        .where_clause("age > 18")
+        .order_by("name", false)
+        .limit(10)
+        .offset(5);
+    
+    assert_eq!(
+        select.build(),
+        "SELECT id, name, email FROM users WHERE age > 18 ORDER BY name ASC LIMIT 10 OFFSET 5"
+    );
+    
+    // Test INSERT query builder
+    let insert = InsertQuery::new("users")
+        .columns(vec!["name", "email"])
+        .values(vec!["'John'", "'john@example.com'"]);
+    
+    assert_eq!(
+        insert.build(),
+        "INSERT INTO users (name, email) VALUES ('John', 'john@example.com')"
+    );
+    
+    // Test UPDATE query builder
+    let update = UpdateQuery::new("users")
+        .set("name", "'Jane'")
+        .set("email", "'jane@example.com'")
+        .where_clause("id = 1");
+    
+    assert_eq!(
+        update.build(),
+        "UPDATE users SET name = 'Jane', email = 'jane@example.com' WHERE id = 1"
+    );
+    
+    // Test DELETE query builder
+    let delete = DeleteQuery::new("users")
+        .where_clause("active = false");
+    
+    assert_eq!(
+        delete.build(),
+        "DELETE FROM users WHERE active = false"
+    );
+}


### PR DESCRIPTION
Add `database-connector` crate for abstracted SQLite (default) and PostgreSQL connections.

This crate provides a foundational, encapsulated layer for future database interactions, supporting both read and write operations.